### PR TITLE
fix: add retry logic for OTA timeout handling

### DIFF
--- a/.github/workflows/bounty-pr-check.yml
+++ b/.github/workflows/bounty-pr-check.yml
@@ -39,6 +39,46 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // Retry logic for fetch with timeout
+            const MAX_RETRIES = 3;
+            const RETRY_DELAY_MS = 1000;
+            const TIMEOUT_MS = 5000;
+
+            async function fetchWithRetry(url, options, retries = MAX_RETRIES) {
+              for (let attempt = 1; attempt <= retries; attempt++) {
+                try {
+                  const controller = new AbortController();
+                  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+                  const response = await fetch(url, {
+                    ...options,
+                    signal: controller.signal,
+                  });
+
+                  clearTimeout(timeoutId);
+
+                  if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                  }
+
+                  return response;
+                } catch (error) {
+                  const isLastAttempt = attempt === retries;
+                  const isTimeout = error.name === 'AbortError';
+
+                  if (isLastAttempt) {
+                    core.error(`RPC call failed after ${retries} attempts: ${error.message}`);
+                    throw error;
+                  }
+
+                  const delay = RETRY_DELAY_MS * attempt;
+                  core.warning(`Attempt ${attempt}/${retries} failed (${isTimeout ? 'timeout' : error.message}), retrying in ${delay}ms...`);
+                  
+                  await new Promise(resolve => setTimeout(resolve, delay));
+                }
+              }
+            }
+
             // Minimal ethers.js balance check via RPC
             const rpc = process.env.AMOY_RPC_URL || 'https://rpc-amoy.polygon.technology';
             const contract = process.env.BOUNTYPOOL_ADDRESS;
@@ -50,8 +90,8 @@ jobs:
               return;
             }
 
-            // eth_getBalance RPC call
-            const resp = await fetch(rpc, {
+            // eth_getBalance RPC call with retry
+            const resp = await fetchWithRetry(rpc, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({

--- a/api/webhook.js
+++ b/api/webhook.js
@@ -11,6 +11,46 @@
 
 const crypto = require("crypto");
 
+// ── Retry logic for fetch requests ──────────────
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 1000; // 1 second base delay
+const TIMEOUT_MS = 5000; // 5 second timeout
+
+async function fetchWithRetry(url, options, retries = MAX_RETRIES) {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+      const response = await fetch(url, {
+        ...options,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      return response;
+    } catch (error) {
+      const isLastAttempt = attempt === retries;
+      const isTimeout = error.name === 'AbortError';
+
+      if (isLastAttempt) {
+        console.error(`Fetch failed after ${retries} attempts:`, error.message);
+        throw error;
+      }
+
+      const delay = RETRY_DELAY_MS * attempt; // Exponential backoff
+      console.warn(`Attempt ${attempt}/${retries} failed (${isTimeout ? 'timeout' : error.message}), retrying in ${delay}ms...`);
+      
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+}
+
 // ── Signature verification ──────────────────────
 function verifySignature(body, signature, secret) {
   if (!secret) return true; // skip in dev
@@ -24,7 +64,7 @@ function verifySignature(body, signature, secret) {
 async function postDiscord(content) {
   const url = process.env.DISCORD_WEBHOOK_URL;
   if (!url) return;
-  await fetch(url, {
+  await fetchWithRetry(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ content }),
@@ -34,7 +74,7 @@ async function postDiscord(content) {
 async function postSlack(text) {
   const url = process.env.SLACK_WEBHOOK_URL;
   if (!url) return;
-  await fetch(url, {
+  await fetchWithRetry(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ text }),


### PR DESCRIPTION
## Summary
- Added \etchWithRetry\ utility function with exponential backoff for handling timeout
- Applied retry logic to webhook Discord/Slack notifications in \pi/webhook.js\
- Applied retry logic to GitHub Actions RPC balance check in \.github/workflows/bounty-pr-check.yml\

## Implementation Details
- **Max retries:** 3 attempts
- **Timeout:** 5 seconds per request
- **Backoff:** Exponential (1s, 2s, 3s delays)
- **Error handling:** Distinguishes between timeout and other errors

## Testing
The retry logic will activate when:
1. Discord/Slack webhook endpoints are slow or unresponsive
2. Polygon Amoy RPC endpoint times out during balance checks

Fixes #1

## Wallet Address for Bounty
\